### PR TITLE
Possibility to show value in opposite to default currency

### DIFF
--- a/src/Torann/Currency/Currency.php
+++ b/src/Torann/Currency/Currency.php
@@ -58,7 +58,7 @@ class Currency {
 		}
 	}
 
-	public function format($number, $currency = null, $symbol_style = '%symbol%')
+	public function format($number, $currency = null, $symbol_style = '%symbol%', $inverse = false)
 	{
 		if ($currency && $this->hasCurrency($currency)) {
       		$symbol_left    = $this->currencies[$currency]['symbol_left'];
@@ -78,7 +78,16 @@ class Currency {
     	}
 
 		if ( $value = $this->currencies[$currency]['value'] ) {
-      		$value = $number * $value;
+      		
+      		if ( $inverse ) {
+
+                $value = $number * (1 / $value);
+
+            } else {
+
+                $value = $number * $value;
+            }
+      		
     	}
     	else {
       		$value = $number;


### PR DESCRIPTION
My default currency is PLN (in config.php)

```
// 1 PLN = X USD
@currency(1, 'USD', null) // -> 0.32
```

Now with `$inverse` parameter:

```
// 1 USD = X PLN
@currency(1, 'USD', null, true) // -> 3.09
```

I don't know how to name this parameter in English, so you can change it to a more appropriate.
