### PR TITLE
add cache_driver configurability

### DIFF
--- a/config/currency.php
+++ b/config/currency.php
@@ -43,6 +43,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Default Storage Driver
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the default cache driver that should be used
+    | by the framework.
+    |
+    | Supported: all cache drivers supported by Laravel
+    |
+    */
+
+    'cache_driver' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Storage Specific Configuration
     |--------------------------------------------------------------------------
     |

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -58,7 +58,7 @@ class Currency
     public function __construct(array $config, FactoryContract $cache)
     {
         $this->config = $config;
-        $this->cache = $cache;
+        $this->cache = $cache->store($this->config('cache_driver'));
     }
 
     /**


### PR DESCRIPTION
Hi, I've added the possibility to use a custom cache driver.
You can configure it in config file.

The $cache member of Currency class, is not a CacheManager instance anymore, but it will be a Repository object.
