### PR TITLE
Don't pass id to INSERT queries.

### DIFF
--- a/src/Drivers/Database.php
+++ b/src/Drivers/Database.php
@@ -42,7 +42,6 @@ class Database extends AbstractDriver
         $created = new DateTime('now');
 
         $params = array_merge([
-            'id' => '',
             'name' => '',
             'code' => '',
             'symbol' => '',


### PR DESCRIPTION
There's no reason to set a value for autoincrementing column here.

Resolves #65