### PR TITLE
Update console commands to use handle instead of fire

### DIFF
--- a/src/Console/Cleanup.php
+++ b/src/Console/Cleanup.php
@@ -42,7 +42,7 @@ class Cleanup extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         // Clear cache
         $this->currency->clearCache();

--- a/src/Console/Manage.php
+++ b/src/Console/Manage.php
@@ -54,7 +54,7 @@ class Manage extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $action = $this->getActionArgument(['add', 'update', 'delete']);
 

--- a/src/Console/Update.php
+++ b/src/Console/Update.php
@@ -44,7 +44,7 @@ class Update extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         // Get Settings
         $defaultCurrency = $this->currency->config('default');


### PR DESCRIPTION
Due to a recent [update](https://github.com/laravel/framework/commit/ac9f29da4785c8b942ced8c4ab308214d618a22b) for Laravel 5.5 the `fire()` method will no longer work for console commands. 

`handle()` now seems to be the only method that can be used.

This should still work for Laravel 5.0+.
