### PR TITLE
Updated timestamp parse method, fixes #87

### DIFF
--- a/src/Console/Update.php
+++ b/src/Console/Update.php
@@ -90,7 +90,7 @@ class Update extends Command
         }
 
         // Parse timestamp for DB
-        $timestamp = new DateTime(strtotime($content->timestamp));
+        $timestamp = (new DateTime())->setTimestamp($content->timestamp);
 
         // Update each rate
         foreach ($content->rates as $code => $value) {


### PR DESCRIPTION
Trying to parse timestamp throws an exception:

[Exception]
DateTime::__construct(): Failed to parse time string (202939474303) at position 10 (0): Unexpected character