### PR TITLE
Add optional softDeletes on a database storage currencies 

### DIFF
--- a/database/migrations/2013_11_26_161501_create_currency_table.php
+++ b/database/migrations/2013_11_26_161501_create_currency_table.php
@@ -35,6 +35,7 @@ class CreateCurrencyTable extends Migration
             $table->string('exchange_rate');
             $table->boolean('active')->default(false);
             $table->timestamps();
+            $table->softDeletes();
         });
     }
 


### PR DESCRIPTION
if the selected storage is Database, add optional soft deletes (deleted_at column).
Backward compatible for current users.

This allows users to extend, create and manage the Currencies model in the Laravel framework