### PR TITLE
Update: BYR->BYN, MRO -> MRU, STD -> STN, SDD -> SDG, VEF-> VES.  Add: GNF, SSP, ZWL

### DIFF
--- a/resources/currencies.php
+++ b/resources/currencies.php
@@ -536,7 +536,7 @@ return [
         'format' => 'MOP$1,0.00',
         'exchange_rate' => 0.00,
     ],
-    'MRO' => [
+    'MRU' => [
         'name' => 'Mauritania, Ouguiya',
         'symbol' => 'UM',
         'format' => '1,0.00UM',
@@ -716,10 +716,10 @@ return [
         'format' => '₨1,0.00',
         'exchange_rate' => 0.00,
     ],
-    'SDD' => [
-        'name' => 'Sudanese Dinar',
-        'symbol' => 'LSd',
-        'format' => '1,0.00LSd',
+    'SDG' => [
+        'name' => 'Sudanese Pound',
+        'symbol' => 'ج.س',
+        'format' => '1,0.00 Sd',
         'exchange_rate' => 0.00,
     ],
     'SEK' => [
@@ -758,7 +758,7 @@ return [
         'format' => '$1,0.00',
         'exchange_rate' => 0.00,
     ],
-    'STD' => [
+    'STN' => [
         'name' => 'Sao Tome and Principe, Dobra',
         'symbol' => 'Db',
         'format' => 'Db1,0.00',

--- a/resources/currencies.php
+++ b/resources/currencies.php
@@ -308,6 +308,12 @@ return [
         'format' => '1,0.00D',
         'exchange_rate' => 0.00,
     ],
+    'GNF' => [
+        'name' => 'Guinean franc',
+        'symbol' => 'FG',
+        'format' => '1,0.00FG',
+        'exchange_rate' => 0.00,
+    ],
     'GTQ' => [
         'name' => 'Guatemala, Quetzal',
         'symbol' => 'Q',
@@ -758,6 +764,12 @@ return [
         'format' => '$1,0.00',
         'exchange_rate' => 0.00,
     ],
+    'SSP' => [
+        'name' => 'South Sudanese pound',
+        'symbol' => 'SS£',
+        'format' => 'SS £1,0.00',
+        'exchange_rate' => 0.00,
+    ],
     'STN' => [
         'name' => 'Sao Tome and Principe, Dobra',
         'symbol' => 'Db',
@@ -866,10 +878,10 @@ return [
         'format' => '1 0,00 сўм',
         'exchange_rate' => 0.00,
     ],
-    'VEF' => [
-        'name' => 'Venezuela Bolivares Fuertes',
-        'symbol' => 'Bs. F.',
-        'format' => 'Bs. F. 1,0.00',
+    'VES' => [
+        'name' => 'Venezuela Bolivares soberano',
+        'symbol' => 'Bs. S.',
+        'format' => 'Bs. S. 1,0.00',
         'exchange_rate' => 0.00,
     ],
     'VND' => [
@@ -930,6 +942,12 @@ return [
         'name' => 'Zambia Kwacha',
         'symbol' => 'ZK',
         'format' => 'ZK1,0.00',
+        'exchange_rate' => 0.00,
+    ],
+    'ZWL' => [
+        'name' => 'Zimbabwean dollar',
+        'symbol' => '$',
+        'format' => '$1,0.00',
         'exchange_rate' => 0.00,
     ],
 ];

--- a/resources/currencies.php
+++ b/resources/currencies.php
@@ -140,7 +140,7 @@ return [
         'format' => 'P1,0.00',
         'exchange_rate' => 0.00,
     ],
-    'BYR' => [
+    'BYN' => [
         'name' => 'Belarussian Ruble',
         'symbol' => 'р.',
         'format' => '1 0,00 р.',


### PR DESCRIPTION
**UPDATE:**
- BYR -> BYN (2016) https://en.wikipedia.org/wiki/Belarusian_ruble
- MRO -> MRU (2017) https://en.wikipedia.org/wiki/Mauritanian_ouguiya
- STD -> STN (2018) https://en.wikipedia.org/wiki/S%C3%A3o_Tom%C3%A9_and_Pr%C3%ADncipe_dobra
- SDD -> SDG (2007) https://en.wikipedia.org/wiki/Sudanese_pound
- VEF -> VES (2018) https://en.wikipedia.org/wiki/Venezuelan_bol%C3%ADvar

**ADD:**
- GNF https://en.wikipedia.org/wiki/Guinean_franc
- SSP https://en.wikipedia.org/wiki/South_Sudanese_pound
- ZWL https://en.wikipedia.org/wiki/Zimbabwean_dollar