### PR TITLE
Support PHP8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
 
 before_script:
   - curl -s http://getcomposer.org/installer | php

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 This provides Laravel with currency functions such as currency formatting and conversion using up-to-date exchange rates.
 
+> ⚠️ Fork of torann/currency for PHP8+
+
 - [Currency on Packagist](https://packagist.org/packages/torann/currency)
 - [Currency on GitHub](https://github.com/torann/laravel-currency)
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "illuminate/support": "^6.0|^7.0|^8.0",
         "illuminate/console": "^6.0|^7.0|^8.0",
         "illuminate/cache": "^6.0|^7.0|^8.0"

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "torann/currency",
-    "description": "This provides Laravel with currency functions such as currency formatting and conversion using up-to-date exchange rates.",
+    "name": "repat/laravel-currency",
+    "description": "This provides Laravel with currency functions such as currency formatting and conversion using up-to-date exchange rates. Fork of torann/currency.",
     "keywords": [
         "laravel",
         "currency",
@@ -8,13 +8,18 @@
         "exchange rate",
         "OpenExchangeRates",
         "Exchange Rates API",
-        "finance"
+        "finance",
+        "torann"
     ],
     "license": "BSD-2-Clause",
     "authors": [
         {
             "name": "Daniel Stainback",
             "email": "torann@gmail.com"
+        },
+        {
+            "name": "repat",
+            "email": "repat@repat.de"
         }
     ],
     "require": {


### PR DESCRIPTION
* `composer update` works with PHP8
* There are no tests, so `phpunit` "works" too
* Looked through some code manually but didn't find anything that would cause problems on PHP8
* `./vendor/bin/phpstan --level=0 --no-progress analyse src` works without problems
* `./vendor/bin/phpcs --standard=phpcs.xml src` works without problems
=> [as expected](https://github.com/Torann/laravel-currency/issues/138), nothing more was needed to support PHP 8