### PR TITLE
Activate currency by default

### DIFF
--- a/src/Drivers/Database.php
+++ b/src/Drivers/Database.php
@@ -46,7 +46,7 @@ class Database extends AbstractDriver
             'symbol' => '',
             'format' => '',
             'exchange_rate' => 1,
-            'active' => 0,
+            'active' => 1,
             'created_at' => $created,
             'updated_at' => $created,
         ], $params);


### PR DESCRIPTION
When currencies are added using this package's artisan add command, the currency is not active by default. Hence, none of the newly added currency is 'usable' by the system to auto-set user currency based on user request (i.e. get request as e.g currency=gbp).
This change ensures that no extra step is needed to use a newly (artisan) added currency