### PR TITLE
Update Kenyan shilling code and format symbol

### DIFF
--- a/resources/currencies.php
+++ b/resources/currencies.php
@@ -412,8 +412,8 @@ return [
     ],
     'KES' => [
         'name' => 'Kenyan Shilling',
-        'symbol' => 'S',
-        'format' => 'S1,0.00',
+        'symbol' => 'KES',
+        'format' => 'KSh1,0.00',
         'exchange_rate' => 0.00,
     ],
     'KGS' => [

--- a/resources/currencies.php
+++ b/resources/currencies.php
@@ -413,7 +413,7 @@ return [
     'KES' => [
         'name' => 'Kenyan Shilling',
         'symbol' => 'KES',
-        'format' => 'KSh1,0.00',
+        'format' => 'Ksh1,0.00',
         'exchange_rate' => 0.00,
     ],
     'KGS' => [


### PR DESCRIPTION
Update Kenyan shilling code and format symbol,

Kenya uses currency code KES and symbol KSh. This update fixes this.