### PR TITLE
Update Kenyan shilling symbol

### DIFF
--- a/resources/currencies.php
+++ b/resources/currencies.php
@@ -412,8 +412,8 @@ return [
     ],
     'KES' => [
         'name' => 'Kenyan Shilling',
-        'symbol' => 'S',
-        'format' => 'S1,0.00',
+        'symbol' => 'Ksh',
+        'format' => 'Ksh1,0.00',
         'exchange_rate' => 0.00,
     ],
     'KGS' => [


### PR DESCRIPTION
Update Kenyan shilling symbol to **Ksh**.

See https://en.wikipedia.org/wiki/Kenyan_shilling