### PR TITLE
Update DriverInterface.php to use ?DateTime

### DIFF
--- a/src/Contracts/DriverInterface.php
+++ b/src/Contracts/DriverInterface.php
@@ -41,7 +41,7 @@ interface DriverInterface
      *
      * @return int
      */
-    public function update($code, array $attributes, DateTime $timestamp = null);
+    public function update($code, array $attributes, ?DateTime $timestamp = null);
 
     /**
      * Remove given currency from storage.


### PR DESCRIPTION
The issue is that the `$timestamp` parameter is optional (has a default value of `null`), but its type hint is `DateTime`, which implies it's not nullable. To fix the deprecation warning, the type hint should be updated to `?DateTime` to explicitly indicate that it's nullable.