### PR TITLE
Add UniRateAPI as a currency:update source

### DIFF
--- a/src/Console/Update.php
+++ b/src/Console/Update.php
@@ -16,6 +16,7 @@ class Update extends Command
     protected $signature = 'currency:update
                                 {--e|exchangeratesapi : Get rates from ExchangeRatesApi.io}
                                 {--o|openexchangerates : Get rates from OpenExchangeRates.org}
+                                {--u|unirate : Get rates from UniRateAPI.com}
                                 {--g|google : Get rates from Google Finance}';
 
     /**
@@ -83,6 +84,17 @@ class Update extends Command
 
             // Get rates from OpenExchangeRates
             return $this->updateFromOpenExchangeRates($defaultCurrency, $api);
+        }
+
+        if ($this->input->getOption('unirate')) {
+            if (! $api = $this->currency->config('api_key')) {
+                $this->error('An API key is needed from UniRateAPI.com to continue.');
+
+                return;
+            }
+
+            // Get rates from UniRateAPI
+            return $this->updateFromUniRate($defaultCurrency, $api);
         }
     }
 
@@ -155,6 +167,40 @@ class Update extends Command
         $this->currency->clearCache();
 
         $this->info('Update!');
+    }
+
+    /**
+     * Fetch rates from the API
+     *
+     * @param $defaultCurrency
+     * @param $api
+     */
+    private function updateFromUniRate($defaultCurrency, $api)
+    {
+        $this->info('Updating currency exchange rates from UniRateAPI.com...');
+
+        // Make request
+        $content = json_decode(
+            $this->request("https://api.unirateapi.com/api/rates?from={$defaultCurrency}&api_key={$api}")
+        );
+
+        // Error getting content?
+        if (isset($content->error)) {
+            $this->error($content->error);
+
+            return;
+        }
+
+        // Update each rate
+        foreach ($content->rates as $code => $value) {
+            $this->currency->getDriver()->update($code, [
+                'exchange_rate' => (float) $value,
+            ]);
+        }
+
+        $this->currency->clearCache();
+
+        $this->info('Updated !');
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds [UniRateAPI](https://unirateapi.com) as a fourth source for `currency:update`, alongside the existing ExchangeRatesApi.io, OpenExchangeRates.org and Google Finance options. Closely follows the existing `--openexchangerates` pattern.

## Why

- Google Finance has been broken for years (the `--google` flow scrapes a converter page that no longer returns the expected `bld>` markup); having more reliable free-tier alternatives is useful.
- UniRateAPI has a free tier (no credit card) covering 170+ fiat and crypto currencies, and a Pro tier for historical data. Its `/api/rates` endpoint mirrors the same `?base=&api_key=` query shape the package already uses for OpenExchangeRates, so the integration is symmetrical and small.
- The existing `api_key` config slot is reused; users who switch to UniRate just put their UniRate key there and pass `--unirate`.

## Changes

- One file: `src/Console/Update.php`
- `+46 / -0` lines:
  - `--u|unirate` flag added to the command signature
  - matching `if ($this->input->getOption('unirate'))` branch in `handle()`, with the same "API key required" guard used by `--openexchangerates`
  - new private `updateFromUniRate($defaultCurrency, $api)` method modeled directly on `updateFromOpenExchangeRates`

## Tested

- `php -l` clean
- Smoke-tested the URL format against the live UniRateAPI endpoint (`/api/rates?from=USD&api_key=…`) — returns `{"base":"USD","rates":{…}}` as expected
- No existing PHPUnit tests for any of the source methods (`tests/` only contains `.gitkeep`), so no test changes required to match the existing precedent

## Notes

- Reuses the existing shared `api_key` config slot (same convention as `--openexchangerates`), so no config/migration changes are required.
- Cast the rate to `(float)` defensively before persisting — UniRate's documented response uses string-form rate values; the cast is harmless if a numeric type is returned.
- Happy to adjust naming, docblocks, or response handling to match maintainer preference.
